### PR TITLE
tasks: avoid modifying input dict

### DIFF
--- a/app/tasks.py
+++ b/app/tasks.py
@@ -10,8 +10,9 @@ class Klass:
 
     @classmethod
     def fromdict(cls, attrs):
-        attrs['value'] = UUID(attrs['value'])
-        return cls(**attrs)
+        new_attrs = attrs.copy()
+        new_attrs['value'] = UUID(attrs['value'])
+        return cls(**new_attrs)
 
 
 @dramatiq.actor


### PR DESCRIPTION
This fixes the issue you encountered in https://github.com/Bogdanp/django_dramatiq/issues/71 . The problem is that the `AdminMiddleware` tries to serialize the params after the message is processed, but `Klass` modifies the `attrs` param in place, setting its `value` field to a `UUID` instance, which the `AdminMiddleware` can't serialize.